### PR TITLE
src/gtkdocklet.c: Fix compilation with gcc-14

### DIFF
--- a/src/gtkdocklet.c
+++ b/src/gtkdocklet.c
@@ -50,6 +50,8 @@
 
 #include "docklet.h"
 
+#include <libpurple/debug.h>
+
 #ifndef DOCKLET_TOOLTIP_LINE_LIMIT
 #define DOCKLET_TOOLTIP_LINE_LIMIT 5
 #endif


### PR DESCRIPTION
otherwise it fails with:
```
  gtkdocklet.c:140:25: error: implicit declaration of function 'purple_debug_warning'; did you mean 'purple_notify_warning'? [-Wimplicit-function-declaration]
    140 |                         purple_debug_warning("docklet",
        |                         ^~~~~~~~~~~~~~~~~~~~
        |                         purple_notify_warning
```